### PR TITLE
Add initial navigation screens

### DIFF
--- a/lib/features/home/presentation/pages/home_page.dart
+++ b/lib/features/home/presentation/pages/home_page.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class HomePage extends StatelessWidget {
+  const HomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Text('Home'),
+    );
+  }
+}

--- a/lib/features/home/presentation/pages/pages.dart
+++ b/lib/features/home/presentation/pages/pages.dart
@@ -1,0 +1,1 @@
+export 'home_page.dart';

--- a/lib/features/main/presentation/pages/main_page.dart
+++ b/lib/features/main/presentation/pages/main_page.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import '../../../home/presentation/pages/home_page.dart';
+import '../../../market/presentation/pages/market_page.dart';
+import '../../../portfolio/presentation/pages/portfolio_page.dart';
+import '../../../news/presentation/pages/news_page.dart';
+import '../../../settings/presentation/pages/settings_page.dart';
+
+class MainPage extends StatefulWidget {
+  const MainPage({super.key});
+
+  @override
+  State<MainPage> createState() => _MainPageState();
+}
+
+class _MainPageState extends State<MainPage> {
+  int _currentIndex = 0;
+
+  final List<Widget> _pages = const [
+    HomePage(),
+    MarketPage(),
+    PortfolioPage(),
+    NewsPage(),
+    SettingsPage(),
+  ];
+
+  void _onItemTapped(int index) {
+    setState(() {
+      _currentIndex = index;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: IndexedStack(
+        index: _currentIndex,
+        children: _pages,
+      ),
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _currentIndex,
+        onTap: _onItemTapped,
+        items: const [
+          BottomNavigationBarItem(icon: Icon(Icons.home), label: 'Home'),
+          BottomNavigationBarItem(icon: Icon(Icons.show_chart), label: 'Market'),
+          BottomNavigationBarItem(icon: Icon(Icons.pie_chart), label: 'Portfolio'),
+          BottomNavigationBarItem(icon: Icon(Icons.article), label: 'News'),
+          BottomNavigationBarItem(icon: Icon(Icons.settings), label: 'Settings'),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/main/presentation/pages/pages.dart
+++ b/lib/features/main/presentation/pages/pages.dart
@@ -1,0 +1,1 @@
+export 'main_page.dart';

--- a/lib/features/market/presentation/pages/market_page.dart
+++ b/lib/features/market/presentation/pages/market_page.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class MarketPage extends StatelessWidget {
+  const MarketPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Text('Market'),
+    );
+  }
+}

--- a/lib/features/market/presentation/pages/pages.dart
+++ b/lib/features/market/presentation/pages/pages.dart
@@ -1,0 +1,1 @@
+export 'market_page.dart';

--- a/lib/features/news/presentation/pages/news_page.dart
+++ b/lib/features/news/presentation/pages/news_page.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class NewsPage extends StatelessWidget {
+  const NewsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Text('News'),
+    );
+  }
+}

--- a/lib/features/news/presentation/pages/pages.dart
+++ b/lib/features/news/presentation/pages/pages.dart
@@ -1,0 +1,1 @@
+export 'news_page.dart';

--- a/lib/features/portfolio/presentation/pages/pages.dart
+++ b/lib/features/portfolio/presentation/pages/pages.dart
@@ -1,0 +1,1 @@
+export 'portfolio_page.dart';

--- a/lib/features/portfolio/presentation/pages/portfolio_page.dart
+++ b/lib/features/portfolio/presentation/pages/portfolio_page.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class PortfolioPage extends StatelessWidget {
+  const PortfolioPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Text('Portfolio'),
+    );
+  }
+}

--- a/lib/features/settings/presentation/pages/pages.dart
+++ b/lib/features/settings/presentation/pages/pages.dart
@@ -1,0 +1,1 @@
+export 'settings_page.dart';

--- a/lib/features/settings/presentation/pages/settings_page.dart
+++ b/lib/features/settings/presentation/pages/settings_page.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class SettingsPage extends StatelessWidget {
+  const SettingsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Text('Settings'),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'features/main/presentation/pages/main_page.dart';
 
 void main() {
   runApp(const MyApp());
@@ -7,116 +8,10 @@ void main() {
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
+    return const MaterialApp(
+      home: MainPage(),
     );
   }
 }


### PR DESCRIPTION
## Summary
- add minimal home, market, portfolio, news and settings features
- implement a main page with BottomNavigationBar
- update main.dart to start at MainPage

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885ee710924832eaa0911493ff23edf