### PR TITLE
Switch to Cupertino UI

### DIFF
--- a/lib/features/data/notifiers/notifiers.dart
+++ b/lib/features/data/notifiers/notifiers.dart
@@ -1,3 +1,3 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 
-ValueNotifier selectedPageNotifer = ValueNotifier(0);
+ValueNotifier<int> selectedPageNotifer = ValueNotifier<int>(0);

--- a/lib/features/presentation/widgets/navbar_widget.dart
+++ b/lib/features/presentation/widgets/navbar_widget.dart
@@ -1,55 +1,39 @@
-import 'dart:ui';
 import 'package:cryphoria_mobile/features/data/notifiers/notifiers.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 
-class NavBarwidget extends StatefulWidget {
-  const NavBarwidget({super.key});
+class NavBarwidget extends StatelessWidget {
+  final int currentIndex;
+  const NavBarwidget({super.key, required this.currentIndex});
 
-  @override
-  State<NavBarwidget> createState() => _NavBarwidgetState();
-}
-
-class _NavBarwidgetState extends State<NavBarwidget> {
   @override
   Widget build(BuildContext context) {
-    return ValueListenableBuilder(valueListenable: selectedPageNotifer, builder: (context, selectedPage, child) {
-        return Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
-          child: ClipRRect(
-            borderRadius: BorderRadius.circular(30),
-            child: BackdropFilter(
-              filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
-              child: Container(
-                color: Colors.white.withOpacity(0.1),
-                // you can tweak elevation/shadows here if you like
-                child: NavigationBar(
-                  backgroundColor: Colors.transparent,
-                  elevation: 0,
-                  selectedIndex: selectedPage,
-                  onDestinationSelected: (int idx) {
-                    selectedPageNotifer.value = idx;
-                  },
-                  destinations: const [
-                    NavigationDestination(
-                        icon: Icon(Icons.home), label: 'Home'),
-                    NavigationDestination(
-                        icon: Icon(Icons.payments_rounded), label: 'Payroll'),
-                    NavigationDestination(
-                        icon: Icon(Icons.account_balance_wallet_sharp),
-                        label: 'Invoice'),
-                    NavigationDestination(
-                        icon: Icon(Icons.report_gmailerrorred),
-                        label: 'Reports'),
-                    NavigationDestination(
-                        icon: Icon(Icons.account_circle_rounded),
-                        label: 'Profile'),
-                  ],
-                ),
-              ),
-            ),
-          ),
-        );
+    return CupertinoTabBar(
+      currentIndex: currentIndex,
+      onTap: (int idx) {
+        selectedPageNotifer.value = idx;
       },
+      items: const [
+        BottomNavigationBarItem(
+          icon: Icon(CupertinoIcons.home),
+          label: 'Home',
+        ),
+        BottomNavigationBarItem(
+          icon: Icon(CupertinoIcons.money_dollar),
+          label: 'Payroll',
+        ),
+        BottomNavigationBarItem(
+          icon: Icon(CupertinoIcons.briefcase),
+          label: 'Invoice',
+        ),
+        BottomNavigationBarItem(
+          icon: Icon(CupertinoIcons.chart_bar),
+          label: 'Reports',
+        ),
+        BottomNavigationBarItem(
+          icon: Icon(CupertinoIcons.person),
+          label: 'Profile',
+        ),
+      ],
     );
   }
 }

--- a/lib/features/presentation/widgets/widgetTree.dart
+++ b/lib/features/presentation/widgets/widgetTree.dart
@@ -6,7 +6,7 @@ import 'package:cryphoria_mobile/features/presentation/pages/Payroll/payroll_vie
 import 'package:cryphoria_mobile/features/presentation/pages/Reports/Reports_Views/reports_views.dart';
 import 'package:cryphoria_mobile/features/presentation/pages/UserProfile/UserProfile_Views/userProfile_Views.dart';
 import 'package:cryphoria_mobile/features/presentation/widgets/navbar_widget.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 
 
 List<Widget> pages = [HomeScreen(), InvoiceScreen(), payrollScreen(), reportsScreen(), userProfile()];
@@ -14,23 +14,25 @@ List<Widget> pages = [HomeScreen(), InvoiceScreen(), payrollScreen(), reportsScr
 class WidgetTree extends StatelessWidget {
   const WidgetTree({super.key});
 
-  
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text('test'),
-        centerTitle: true,
-        
-      ),
-      body: ValueListenableBuilder(
-        valueListenable: selectedPageNotifer,
-        builder: (context, selectedPage, child) {
-          return pages.elementAt(selectedPage);
-        },
-      ),
-
-      bottomNavigationBar: NavBarwidget(),
+    return ValueListenableBuilder(
+      valueListenable: selectedPageNotifer,
+      builder: (context, selectedPage, child) {
+        return CupertinoTabScaffold(
+          tabBar: NavBarwidget(currentIndex: selectedPage),
+          tabBuilder: (context, index) {
+            return CupertinoTabView(
+              builder: (context) => CupertinoPageScaffold(
+                navigationBar: const CupertinoNavigationBar(
+                  middle: Text('test'),
+                ),
+                child: pages.elementAt(index),
+              ),
+            );
+          },
+        );
+      },
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,11 @@
 import 'package:cryphoria_mobile/features/presentation/widgets/widgetTree.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 
 void main() {
-  runApp(MaterialApp(
-    home: WidgetTree(),
-    debugShowCheckedModeBanner: false,
-  ));
+  runApp(
+    const CupertinoApp(
+      home: WidgetTree(),
+      debugShowCheckedModeBanner: false,
+    ),
+  );
 }


### PR DESCRIPTION
## Summary
- use `CupertinoApp` instead of `MaterialApp`
- refactor `WidgetTree` to `CupertinoTabScaffold`
- replace `NavigationBar` with `CupertinoTabBar`
- remove Material imports

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68872b9d2c08832e8cbf9ed0324eedeb