### PR TITLE
Fix overflow in invoice toggle buttons

### DIFF
--- a/lib/features/presentation/pages/Invoice/InvoiceViews/invoice_views.dart
+++ b/lib/features/presentation/pages/Invoice/InvoiceViews/invoice_views.dart
@@ -168,9 +168,9 @@ class _InvoiceScreenState extends State<InvoiceScreen> {
                             fillColor: const Color(0xFF5B50FF),
                             selectedColor: Colors.white,
                             color: Colors.white70,
-                            constraints: BoxConstraints(
-                              minHeight: 40,
-                              minWidth: buttonWidth,
+                            constraints: BoxConstraints.tightFor(
+                              height: 40,
+                              width: buttonWidth,
                             ),
 
                             children: _filters


### PR DESCRIPTION
## Summary
- fix layout overflow in Invoice screen segmented control by tightening toggle button constraints

## Testing
- `flutter analyze` *(fails: Requires Dart SDK >=3.8.1)*
- `flutter test` *(fails: Requires Dart SDK >=3.8.1)*

------
https://chatgpt.com/codex/tasks/task_e_6888abb1cb1c832eb5efa7cc636fd72a