### PR TITLE
Refactor summary cards into reusable widget

### DIFF
--- a/lib/features/presentation/pages/Invoice/InvoiceViews/invoice_views.dart
+++ b/lib/features/presentation/pages/Invoice/InvoiceViews/invoice_views.dart
@@ -1,5 +1,6 @@
 import 'dart:ui';
 import 'package:cryphoria_mobile/features/presentation/widgets/cardwallet.dart';
+import 'package:cryphoria_mobile/features/presentation/widgets/summary_glass_card.dart';
 import 'package:cryphoria_mobile/features/presentation/widgets/invoice_ItemCard.dart';
 import 'package:cryphoria_mobile/features/presentation/widgets/refresh_icon.dart';
 import 'package:flutter/material.dart';
@@ -88,53 +89,22 @@ class _InvoiceScreenState extends State<InvoiceScreen> {
                   Row(
                     children: [
                       Expanded(
-                        child: GlassCard(
-                          child: Padding(
-                            padding: const EdgeInsets.all(20),
-                            child: Column(
-                              mainAxisSize: MainAxisSize.min,
-                              children: const [
-                                Text(
-                                  'Total Billed Amount',
-                                  style: TextStyle(color: Colors.white54),
-                                ),
-                                SizedBox(height: 8),
-                                Text(
-                                  '₱12,340',
-                                  style: TextStyle(
-                                    color: Colors.white,
-                                    fontSize: 18,
-                                    fontWeight: FontWeight.bold,
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ),
+                        child: SummaryGlassCard(
+                          title: 'Total Billed Amount',
+                          value: '₱12,340',
+                          padding: const EdgeInsets.all(20),
                         ),
                       ),
                       const SizedBox(width: 16),
                       Expanded(
-                        child: GlassCard(
-                          child: Padding(
-                            padding: const EdgeInsets.all(20),
-                            child: Column(
-                              mainAxisSize: MainAxisSize.min,
-                              children: const [
-                                Text(
-                                  'Paid Invoices',
-                                  style: TextStyle(color: Colors.white54),
-                                ),
-                                SizedBox(height: 8),
-                                Text(
-                                  '10',
-                                  style: TextStyle(
-                                    color: Colors.white,
-                                    fontSize: 20,
-                                    fontWeight: FontWeight.bold,
-                                  ),
-                                ),
-                              ],
-                            ),
+                        child: SummaryGlassCard(
+                          title: 'Paid Invoices',
+                          value: '10',
+                          padding: const EdgeInsets.all(20),
+                          valueStyle: const TextStyle(
+                            color: Colors.white,
+                            fontSize: 20,
+                            fontWeight: FontWeight.bold,
                           ),
                         ),
                       ),

--- a/lib/features/presentation/pages/Payroll/payroll_views/payroll_Views.dart
+++ b/lib/features/presentation/pages/Payroll/payroll_views/payroll_Views.dart
@@ -5,6 +5,7 @@ import 'package:cryphoria_mobile/features/presentation/widgets/historyWidget.dar
 import 'package:cryphoria_mobile/features/presentation/widgets/payroll_ItemWidget.dart';
 import 'package:flutter/material.dart';
 import 'package:cryphoria_mobile/features/presentation/widgets/cardwallet.dart'; // your GlassCard
+import 'package:cryphoria_mobile/features/presentation/widgets/summary_glass_card.dart';
 
 class payrollScreen extends StatelessWidget {
   const payrollScreen({super.key});
@@ -91,53 +92,27 @@ class payrollScreen extends StatelessWidget {
                   Row(
                     children: [
                       Expanded(
-                        child: GlassCard(
-                          child: Padding(
-                            padding: const EdgeInsets.all(10),
-                            child: Column(
-                              mainAxisSize: MainAxisSize.min,
-                              children: const [
-                                Text(
-                                  'Total Payroll',
-                                  style: TextStyle(color: Colors.white54),
-                                ),
-                                SizedBox(height: 8),
-                                Text(
-                                  '₱12,340',
-                                  style: TextStyle(
-                                    color: Colors.white,
-                                    fontSize: 20,
-                                    fontWeight: FontWeight.bold,
-                                  ),
-                                ),
-                              ],
-                            ),
+                        child: SummaryGlassCard(
+                          title: 'Total Payroll',
+                          value: '₱12,340',
+                          padding: const EdgeInsets.all(10),
+                          valueStyle: const TextStyle(
+                            color: Colors.white,
+                            fontSize: 20,
+                            fontWeight: FontWeight.bold,
                           ),
                         ),
                       ),
                       const SizedBox(width: 16),
                       Expanded(
-                        child: GlassCard(
-                          child: Padding(
-                            padding: const EdgeInsets.all(10),
-                            child: Column(
-                              mainAxisSize: MainAxisSize.min,
-                              children: const [
-                                Text(
-                                  'Next Payroll Due',
-                                  style: TextStyle(color: Colors.white54),
-                                ),
-                                SizedBox(height: 8),
-                                Text(
-                                  '26 August 2025',
-                                  style: TextStyle(
-                                    color: Colors.white,
-                                    fontSize: 18,
-                                    fontWeight: FontWeight.bold,
-                                  ),
-                                ),
-                              ],
-                            ),
+                        child: SummaryGlassCard(
+                          title: 'Next Payroll Due',
+                          value: '26 August 2025',
+                          padding: const EdgeInsets.all(10),
+                          valueStyle: const TextStyle(
+                            color: Colors.white,
+                            fontSize: 18,
+                            fontWeight: FontWeight.bold,
                           ),
                         ),
                       ),

--- a/lib/features/presentation/widgets/summary_glass_card.dart
+++ b/lib/features/presentation/widgets/summary_glass_card.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'cardwallet.dart';
+
+/// A simple glass-style summary card used across invoice and payroll screens.
+class SummaryGlassCard extends StatelessWidget {
+  /// Label displayed above the value.
+  final String title;
+
+  /// Main value text of the card.
+  final String value;
+
+  /// Optional style for the title text.
+  final TextStyle? titleStyle;
+
+  /// Optional style for the value text.
+  final TextStyle? valueStyle;
+
+  /// Padding around the content of the card.
+  final EdgeInsets padding;
+
+  const SummaryGlassCard({
+    Key? key,
+    required this.title,
+    required this.value,
+    this.titleStyle,
+    this.valueStyle,
+    this.padding = const EdgeInsets.all(16),
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return GlassCard(
+      child: Padding(
+        padding: padding,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              title,
+              style: titleStyle ?? const TextStyle(color: Colors.white54),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              value,
+              style: valueStyle ??
+                  const TextStyle(
+                    color: Colors.white,
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                  ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `SummaryGlassCard` widget for simple title/value glass cards
- use `SummaryGlassCard` in invoice and payroll views

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68899fbd0ca0832e9074c77ccf2c1a2f