### PR TITLE
Fix failing widget test

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -6,26 +6,14 @@
 // tree, read text, and verify that the values of widget properties are correct.
 
 import 'package:cryphoria_mobile/features/presentation/pages/Authentication/SignUp/Views/signupview.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:cryphoria_mobile/main.dart';
-
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
+  testWidgets('SignUpPage renders correctly', (WidgetTester tester) async {
+    // Build the SignUpPage widget.
     await tester.pumpWidget(const SignUpPage());
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    // Verify that the page displays the "Create Account" heading.
+    expect(find.text('Create Account'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- update widget test to verify SignUpPage heading

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_688ad1431188832e9ba1610feedd343c