### PR TITLE
Fix invalid image asset error

### DIFF
--- a/lib/features/presentation/pages/Home/home_views/homeView.dart
+++ b/lib/features/presentation/pages/Home/home_views/homeView.dart
@@ -4,6 +4,7 @@ import 'package:cryphoria_mobile/features/presentation/widgets/refresh_icon.dart
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 
 import '../../../widgets/line_chart.dart';
 import '../../../widgets/navbar_widget.dart';
@@ -526,11 +527,14 @@ class HomeScreen extends StatelessWidget {
                                             shape: BoxShape.circle,
                                           ),
                                           child: Center(
-                                            child: Image.asset(
+                                            child: SvgPicture.asset(
                                               'assets/icons/cash_inflow.svg',
                                               width: 28,
                                               height: 28,
-                                              color: Colors.white,
+                                              colorFilter: const ColorFilter.mode(
+                                                Colors.white,
+                                                BlendMode.srcIn,
+                                              ),
                                             ),
                                           ),
                                         ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -73,6 +73,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  flutter_svg:
+    dependency: "direct main"
+    description:
+      name: flutter_svg
+      sha256: cd57f7969b4679317c17af6fd16ee233c1e60a82ed209d8a475c54fd6fd6f845
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,6 +33,7 @@ dependencies:
 
   material_design_icons_flutter: 7.0.7296
   fl_chart: ^1.0.0
+  flutter_svg: ^2.2.0
 
 
   # The following adds the Cupertino Icons font to your application.


### PR DESCRIPTION
## Summary
- add `flutter_svg` to handle SVG icons
- use `SvgPicture.asset` for inflow icon

## Testing
- `flutter --version` *(fails: 'flutter tool version check' with SDK 3.3.4)*

------
https://chatgpt.com/codex/tasks/task_e_688ad47c9e84832e99d3fd263a5fdddf