### PR TITLE
Show authentication pages before main widget tree

### DIFF
--- a/lib/features/presentation/pages/Authentication/LogIn/Views/login_views.dart
+++ b/lib/features/presentation/pages/Authentication/LogIn/Views/login_views.dart
@@ -1,23 +1,6 @@
 import 'package:cryphoria_mobile/dependency_injection/di.dart';
 import 'package:cryphoria_mobile/features/presentation/pages/Authentication/LogIn/ViewModel/login_ViewModel.dart';
-import 'package:cryphoria_mobile/features/presentation/widgets/widget_tree.dart';
 import 'package:flutter/material.dart';
-
-void main() {
-  runApp(const LogInPage());
-}
-
-class LogInPage extends StatelessWidget {
-  const LogInPage({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      debugShowCheckedModeBanner: false,
-      home: const LogIn(),
-    );
-  }
-}
 
 class LogIn extends StatefulWidget {
   const LogIn({super.key});
@@ -39,12 +22,11 @@ class _LogInState extends State<LogIn> {
 
   void _onViewModelChanged() {
     if (_viewModel.authUser != null) {
-      Navigator.of(context).pushReplacement(
-        MaterialPageRoute(builder: (_) => const WidgetTree()),
-      );
+      Navigator.of(context).pushReplacementNamed('/home');
     } else if (_viewModel.error != null) {
-      ScaffoldMessenger.of(context)
-          .showSnackBar(SnackBar(content: Text(_viewModel.error!)));
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(_viewModel.error!)));
     }
   }
 
@@ -72,7 +54,11 @@ class _LogInState extends State<LogIn> {
                 // Title
                 const Text(
                   'Welcome back!',
-                  style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold, color: Colors.white),
+                  style: TextStyle(
+                    fontSize: 24,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.white,
+                  ),
                 ),
                 const SizedBox(height: 8),
                 // Subtitle
@@ -82,9 +68,16 @@ class _LogInState extends State<LogIn> {
                 ),
                 const SizedBox(height: 30),
                 // Input Fields
-                buildInputField('Username or email', controller: _usernameController),
+                buildInputField(
+                  'Username or email',
+                  controller: _usernameController,
+                ),
                 const SizedBox(height: 16),
-                buildInputField('Password', controller: _passwordController, obscure: true),
+                buildInputField(
+                  'Password',
+                  controller: _passwordController,
+                  obscure: true,
+                ),
 
                 Row(
                   mainAxisAlignment: MainAxisAlignment.end,
@@ -112,7 +105,9 @@ class _LogInState extends State<LogIn> {
                   child: ElevatedButton(
                     style: ElevatedButton.styleFrom(
                       backgroundColor: const Color(0xFF9747FF),
-                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8),
+                      ),
                     ),
                     onPressed: () {
                       _viewModel.login(
@@ -122,24 +117,34 @@ class _LogInState extends State<LogIn> {
                     },
                     child: const Text(
                       'Log In',
-                      style: TextStyle(fontWeight: FontWeight.bold, color: Colors.white),
+                      style: TextStyle(
+                        fontWeight: FontWeight.bold,
+                        color: Colors.white,
+                      ),
                     ),
                   ),
                 ),
                 const SizedBox(height: 24),
 
-                // Login redirect
+                // Sign Up redirect
                 Center(
-                  child: RichText(
-                    text: const TextSpan(
-                      text: 'Already have an Account? ',
-                      style: TextStyle(color: Colors.white),
-                      children: [
-                        TextSpan(
-                          text: 'Sign Up',
-                          style: TextStyle(fontWeight: FontWeight.bold, color: Colors.white),
-                        ),
-                      ],
+                  child: GestureDetector(
+                    onTap: () =>
+                        Navigator.pushReplacementNamed(context, '/signup'),
+                    child: RichText(
+                      text: const TextSpan(
+                        text: 'Don\'t have an Account? ',
+                        style: TextStyle(color: Colors.white),
+                        children: [
+                          TextSpan(
+                            text: 'Sign Up',
+                            style: TextStyle(
+                              fontWeight: FontWeight.bold,
+                              color: Colors.white,
+                            ),
+                          ),
+                        ],
+                      ),
                     ),
                   ),
                 ),
@@ -152,14 +157,20 @@ class _LogInState extends State<LogIn> {
   }
 
   //hihiwalay to sa widget
-  Widget buildInputField(String hint,
-      {required TextEditingController controller, bool obscure = false}) {
+  Widget buildInputField(
+    String hint, {
+    required TextEditingController controller,
+    bool obscure = false,
+  }) {
     return TextField(
       controller: controller,
       obscureText: obscure,
       decoration: InputDecoration(
         hintText: hint,
-        contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: 16,
+          vertical: 16,
+        ),
         border: OutlineInputBorder(borderRadius: BorderRadius.circular(8)),
       ),
     );

--- a/lib/features/presentation/pages/Authentication/SignUp/Views/signupview.dart
+++ b/lib/features/presentation/pages/Authentication/SignUp/Views/signupview.dart
@@ -1,23 +1,6 @@
 import 'package:cryphoria_mobile/dependency_injection/di.dart';
 import 'package:cryphoria_mobile/features/presentation/pages/Authentication/SignUp/ViewModel/signup_ViewModel.dart';
-import 'package:cryphoria_mobile/features/presentation/widgets/widget_tree.dart';
 import 'package:flutter/material.dart';
-
-void main() {
-  runApp(const SignUpPage());
-}
-
-class SignUpPage extends StatelessWidget {
-  const SignUpPage({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      debugShowCheckedModeBanner: false,
-      home: const SignUp(),
-    );
-  }
-}
 
 class SignUp extends StatefulWidget {
   const SignUp({super.key});
@@ -41,12 +24,11 @@ class _SignUpState extends State<SignUp> {
 
   void _onViewModelChanged() {
     if (_viewModel.authUser != null) {
-      Navigator.of(context).pushReplacement(
-        MaterialPageRoute(builder: (_) => const WidgetTree()),
-      );
+      Navigator.of(context).pushReplacementNamed('/home');
     } else if (_viewModel.error != null) {
-      ScaffoldMessenger.of(context)
-          .showSnackBar(SnackBar(content: Text(_viewModel.error!)));
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(_viewModel.error!)));
     }
   }
 
@@ -76,7 +58,11 @@ class _SignUpState extends State<SignUp> {
                 // Title
                 const Text(
                   'Create Account',
-                  style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold, color: Colors.white),
+                  style: TextStyle(
+                    fontSize: 24,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.white,
+                  ),
                 ),
                 const SizedBox(height: 8),
                 // Subtitle
@@ -86,13 +72,20 @@ class _SignUpState extends State<SignUp> {
                 ),
                 const SizedBox(height: 30),
                 // Input Fields
-                buildInputField('Business Name', controller: _businessController),
+                buildInputField(
+                  'Business Name',
+                  controller: _businessController,
+                ),
                 const SizedBox(height: 16),
                 buildInputField('Username', controller: _usernameController),
                 const SizedBox(height: 16),
                 buildInputField('Email', controller: _emailController),
                 const SizedBox(height: 24),
-                buildInputField('Password', controller: _passwordController, obscure: true),
+                buildInputField(
+                  'Password',
+                  controller: _passwordController,
+                  obscure: true,
+                ),
                 const SizedBox(height: 24),
                 // Sign Up Button
                 SizedBox(
@@ -101,7 +94,9 @@ class _SignUpState extends State<SignUp> {
                   child: ElevatedButton(
                     style: ElevatedButton.styleFrom(
                       backgroundColor: const Color(0xFF9747FF),
-                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8),
+                      ),
                     ),
                     onPressed: () {
                       _viewModel.signup(
@@ -112,7 +107,10 @@ class _SignUpState extends State<SignUp> {
                     },
                     child: const Text(
                       'Sign Up',
-                      style: TextStyle(fontWeight: FontWeight.bold, color: Colors.white),
+                      style: TextStyle(
+                        fontWeight: FontWeight.bold,
+                        color: Colors.white,
+                      ),
                     ),
                   ),
                 ),
@@ -126,7 +124,8 @@ class _SignUpState extends State<SignUp> {
                       child: Text(
                         'OR',
                         style: TextStyle(
-                          color: Colors.white60, // 👈 change this to any color you want
+                          color: Colors
+                              .white60, // 👈 change this to any color you want
                           fontWeight: FontWeight.normal,
                         ),
                       ),
@@ -137,24 +136,32 @@ class _SignUpState extends State<SignUp> {
                 const SizedBox(height: 20),
                 // Social Buttons
                 buildSocialButton(
-                  iconUrl: 'https://img.icons8.com/?size=100&id=Oi106YG9IoLv&format=png&color=000000',
+                  iconUrl:
+                      'https://img.icons8.com/?size=100&id=Oi106YG9IoLv&format=png&color=000000',
                   text: 'Connect Metamask',
                   color: const Color(0xFF1A1A2E),
                 ),
 
                 const SizedBox(height: 30),
-                // Login redirect
+                // Log In redirect
                 Center(
-                  child: RichText(
-                    text: const TextSpan(
-                      text: 'Already have an Account? ',
-                      style: TextStyle(color: Colors.white),
-                      children: [
-                        TextSpan(
-                          text: 'Log In',
-                          style: TextStyle(fontWeight: FontWeight.bold, color: Colors.white),
-                        ),
-                      ],
+                  child: GestureDetector(
+                    onTap: () =>
+                        Navigator.pushReplacementNamed(context, '/login'),
+                    child: RichText(
+                      text: const TextSpan(
+                        text: 'Already have an Account? ',
+                        style: TextStyle(color: Colors.white),
+                        children: [
+                          TextSpan(
+                            text: 'Log In',
+                            style: TextStyle(
+                              fontWeight: FontWeight.bold,
+                              color: Colors.white,
+                            ),
+                          ),
+                        ],
+                      ),
                     ),
                   ),
                 ),
@@ -168,14 +175,20 @@ class _SignUpState extends State<SignUp> {
   }
 
   // Reusable text input
-  Widget buildInputField(String hint,
-      {required TextEditingController controller, bool obscure = false}) {
+  Widget buildInputField(
+    String hint, {
+    required TextEditingController controller,
+    bool obscure = false,
+  }) {
     return TextField(
       controller: controller,
       obscureText: obscure,
       decoration: InputDecoration(
         hintText: hint,
-        contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: 16,
+          vertical: 16,
+        ),
         border: OutlineInputBorder(borderRadius: BorderRadius.circular(8)),
       ),
     );
@@ -208,17 +221,11 @@ class _SignUpState extends State<SignUp> {
                 width: 24,
                 height: 24,
                 fit: BoxFit.contain,
-                errorBuilder: (context, error, stackTrace) => const Icon(
-                  Icons.error,
-                  size: 24,
-                ),
+                errorBuilder: (context, error, stackTrace) =>
+                    const Icon(Icons.error, size: 24),
               )
             else
-              Icon(
-                icon ?? Icons.error,
-                color: Colors.white,
-                size: 24,
-              ),
+              Icon(icon ?? Icons.error, color: Colors.white, size: 24),
             const SizedBox(width: 8),
             Text(
               text,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,8 @@
 import 'package:cryphoria_mobile/dependency_injection/di.dart' as di;
 import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:cryphoria_mobile/features/presentation/pages/Authentication/LogIn/Views/login_views.dart';
+import 'package:cryphoria_mobile/features/presentation/pages/Authentication/SignUp/Views/signupview.dart';
 import 'package:cryphoria_mobile/features/presentation/widgets/widget_tree.dart';
 
 Future<void> main() async {
@@ -11,7 +13,7 @@ Future<void> main() async {
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
-  
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -20,7 +22,12 @@ class MyApp extends StatelessWidget {
         primaryColor: Colors.purple,
         scaffoldBackgroundColor: Colors.black,
       ),
-      home: const WidgetTree(),
+      initialRoute: '/login',
+      routes: {
+        '/login': (context) => const LogIn(),
+        '/signup': (context) => const SignUp(),
+        '/home': (context) => const WidgetTree(),
+      },
     );
   }
 }


### PR DESCRIPTION
## Summary
- Route the app to login and signup screens at startup
- Navigate to main widget tree after successful authentication and cross-link login/signup

## Testing
- `dart format lib/main.dart lib/features/presentation/pages/Authentication/LogIn/Views/login_views.dart lib/features/presentation/pages/Authentication/SignUp/Views/signupview.dart`
- `dart test` *(fails: Flutter SDK is not available)*

------
https://chatgpt.com/codex/tasks/task_e_688e45543290832e9909257217a19557