### PR TITLE
Persist auth token and improve authentication errors

### DIFF
--- a/lib/core/error/excemptions.dart
+++ b/lib/core/error/excemptions.dart
@@ -1,3 +1,0 @@
-class ServerException implements Exception {
-  
-}

--- a/lib/core/error/exceptions.dart
+++ b/lib/core/error/exceptions.dart
@@ -1,0 +1,7 @@
+class ServerException implements Exception {
+  final String message;
+  ServerException(this.message);
+
+  @override
+  String toString() => message;
+}

--- a/lib/core/network/dio_client.dart
+++ b/lib/core/network/dio_client.dart
@@ -1,14 +1,23 @@
 import 'package:dio/dio.dart';
 
+import '../../features/data/data_sources/AuthLocalDataSource.dart';
+
 class DioClient {
   final Dio dio;
+  final AuthLocalDataSource localDataSource;
 
-  DioClient({Dio? dio})
+  DioClient({required this.localDataSource, Dio? dio})
       : dio = dio ??
             Dio(BaseOptions(
               connectTimeout: const Duration(milliseconds: 5000),
               receiveTimeout: const Duration(milliseconds: 3000),
-            ));
-
-  // Add interceptors or common error handling if needed.
+            )) {
+    this.dio.interceptors.add(InterceptorsWrapper(onRequest: (options, handler) async {
+      final token = await localDataSource.getToken();
+      if (token != null) {
+        options.headers['Authorization'] = 'Token $token';
+      }
+      handler.next(options);
+    }));
+  }
 }

--- a/lib/dependency_injection/di.dart
+++ b/lib/dependency_injection/di.dart
@@ -1,3 +1,6 @@
+import 'dart:io';
+
+import 'package:cryphoria_mobile/features/data/data_sources/AuthLocalDataSource.dart';
 import 'package:cryphoria_mobile/features/data/data_sources/AuthRemoteDataSource.dart';
 import 'package:cryphoria_mobile/features/data/repositories_impl/AuthRepositoryImpl.dart';
 import 'package:cryphoria_mobile/features/domain/repositories/auth_repository.dart';
@@ -7,27 +10,38 @@ import 'package:cryphoria_mobile/features/presentation/pages/Authentication/LogI
 import 'package:cryphoria_mobile/features/presentation/pages/Authentication/SignUp/ViewModel/signup_ViewModel.dart';
 import 'package:dio/dio.dart';
 import 'package:get_it/get_it.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../core/network/dio_client.dart';
-
 
 final sl = GetIt.instance;
 
 Future<void> init() async {
+  final sharedPreferences = await SharedPreferences.getInstance();
+  sl.registerLazySingleton(() => sharedPreferences);
+
   // Core
-  sl.registerLazySingleton(() => DioClient(dio: Dio()));
+  sl.registerLazySingleton<AuthLocalDataSource>(() => AuthLocalDataSourceImpl(sharedPreferences: sl()));
+  sl.registerLazySingleton(() => DioClient(localDataSource: sl(), dio: Dio()));
+
+  String _baseUrl() {
+    if (Platform.isAndroid) {
+      return 'http://10.0.2.2:8000';
+    }
+    return 'http://127.0.0.1:8000';
+  }
 
   // Data sources
   sl.registerLazySingleton<AuthRemoteDataSource>(
     () => AuthRemoteDataSourceImpl(
       dio: sl<DioClient>().dio,
-      baseUrl: 'http://localhost:8000',
+      baseUrl: _baseUrl(),
     ),
   );
 
   // Repository
   sl.registerLazySingleton<AuthRepository>(
-    () => AuthRepositoryImpl(sl<AuthRemoteDataSource>()),
+    () => AuthRepositoryImpl(sl<AuthRemoteDataSource>(), sl<AuthLocalDataSource>()),
   );
 
   // Use cases

--- a/lib/features/data/data_sources/AuthLocalDataSource.dart
+++ b/lib/features/data/data_sources/AuthLocalDataSource.dart
@@ -1,0 +1,23 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+abstract class AuthLocalDataSource {
+  Future<void> cacheToken(String token);
+  Future<String?> getToken();
+}
+
+class AuthLocalDataSourceImpl implements AuthLocalDataSource {
+  final SharedPreferences sharedPreferences;
+  static const _tokenKey = 'auth_token';
+
+  AuthLocalDataSourceImpl({required this.sharedPreferences});
+
+  @override
+  Future<void> cacheToken(String token) async {
+    await sharedPreferences.setString(_tokenKey, token);
+  }
+
+  @override
+  Future<String?> getToken() async {
+    return sharedPreferences.getString(_tokenKey);
+  }
+}

--- a/lib/features/data/data_sources/AuthRemoteDataSource.dart
+++ b/lib/features/data/data_sources/AuthRemoteDataSource.dart
@@ -1,6 +1,5 @@
-import 'package:cryphoria_mobile/core/error/excemptions.dart';
+import 'package:cryphoria_mobile/core/error/exceptions.dart';
 import 'package:dio/dio.dart';
-
 
 abstract class AuthRemoteDataSource {
   Future<String> login(String username, String password);
@@ -22,11 +21,11 @@ class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
       );
       if (response.statusCode == 200) {
         return response.data['token'];
-      } else {
-        throw ServerException();
       }
-    } on DioError catch (_) {
-      throw ServerException();
+      throw ServerException(response.data['detail']?.toString() ?? 'Login failed');
+    } on DioException catch (e) {
+      final message = e.response?.data['detail']?.toString() ?? 'Login failed';
+      throw ServerException(message);
     }
   }
 
@@ -39,11 +38,11 @@ class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
       );
       if (response.statusCode == 200) {
         return response.data['token'];
-      } else {
-        throw ServerException();
       }
-    } on DioError catch (_) {
-      throw ServerException();
+      throw ServerException(response.data['detail']?.toString() ?? 'Registration failed');
+    } on DioException catch (e) {
+      final message = e.response?.data['detail']?.toString() ?? 'Registration failed';
+      throw ServerException(message);
     }
   }
 }

--- a/lib/features/data/repositories_impl/AuthRepositoryImpl.dart
+++ b/lib/features/data/repositories_impl/AuthRepositoryImpl.dart
@@ -1,3 +1,4 @@
+import 'package:cryphoria_mobile/features/data/data_sources/AuthLocalDataSource.dart';
 import 'package:cryphoria_mobile/features/data/data_sources/AuthRemoteDataSource.dart';
 import 'package:cryphoria_mobile/features/domain/repositories/auth_repository.dart';
 
@@ -5,18 +6,21 @@ import '../../domain/entities/auth_user.dart';
 
 class AuthRepositoryImpl implements AuthRepository {
   final AuthRemoteDataSource remoteDataSource;
+  final AuthLocalDataSource localDataSource;
 
-  AuthRepositoryImpl(this.remoteDataSource);
+  AuthRepositoryImpl(this.remoteDataSource, this.localDataSource);
 
   @override
   Future<AuthUser> login(String username, String password) async {
     final token = await remoteDataSource.login(username, password);
+    await localDataSource.cacheToken(token);
     return AuthUser(token: token);
   }
 
   @override
   Future<AuthUser> register(String username, String password, String email) async {
     final token = await remoteDataSource.register(username, password, email);
+    await localDataSource.cacheToken(token);
     return AuthUser(token: token);
   }
 }

--- a/lib/features/presentation/pages/Authentication/LogIn/ViewModel/login_ViewModel.dart
+++ b/lib/features/presentation/pages/Authentication/LogIn/ViewModel/login_ViewModel.dart
@@ -1,7 +1,7 @@
+import 'package:cryphoria_mobile/core/error/exceptions.dart';
 import 'package:cryphoria_mobile/features/domain/entities/auth_user.dart';
 import 'package:cryphoria_mobile/features/domain/usecases/Login/login_usecase.dart';
 import 'package:flutter/foundation.dart';
-
 
 class LoginViewModel extends ChangeNotifier {
   final Login loginUseCase;
@@ -18,6 +18,8 @@ class LoginViewModel extends ChangeNotifier {
     try {
       _authUser = await loginUseCase.execute(username, password);
       _error = null;
+    } on ServerException catch (e) {
+      _error = e.message;
     } catch (e) {
       _error = "Login failed";
     }

--- a/lib/features/presentation/pages/Authentication/SignUp/ViewModel/signup_ViewModel.dart
+++ b/lib/features/presentation/pages/Authentication/SignUp/ViewModel/signup_ViewModel.dart
@@ -1,7 +1,7 @@
+import 'package:cryphoria_mobile/core/error/exceptions.dart';
 import 'package:cryphoria_mobile/features/domain/entities/auth_user.dart';
 import 'package:cryphoria_mobile/features/domain/usecases/Register/register_use_case.dart';
 import 'package:flutter/foundation.dart';
-
 
 class SignupViewModel extends ChangeNotifier {
   final Register registerUseCase;
@@ -18,11 +18,11 @@ class SignupViewModel extends ChangeNotifier {
     try {
       _authUser = await registerUseCase.execute(username, password, email);
       _error = null;
+    } on ServerException catch (e) {
+      _error = e.message;
     } catch (e) {
       _error = "Registration failed";
     }
     notifyListeners();
   }
 }
-
-  

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,7 +40,8 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
   dio: ^5.8.0+1
-  get_it: ^7.6.0 
+  get_it: ^7.6.0
+  shared_preferences: ^2.2.2
 
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- persist API token locally using `SharedPreferences`
- attach Authorization header automatically via Dio interceptor
- improve error propagation and surface backend messages
- use platform-aware base URL for emulator/device access

## Testing
- `flutter test` *(fails: command not found: flutter)*


------
https://chatgpt.com/codex/tasks/task_e_688f802e1e78832e99b6add6a4728bbd