### PR TITLE
Register wallet repository in service locator

### DIFF
--- a/lib/dependency_injection/di.dart
+++ b/lib/dependency_injection/di.dart
@@ -57,18 +57,24 @@ Future<void> init() async {
   sl.registerFactory(() => LoginViewModel(loginUseCase: sl()));
   sl.registerFactory(() => RegisterViewModel(registerUseCase: sl()));
 
+  // Wallet feature
+  final token = await sl<AuthLocalDataSource>().getToken() ?? "";
 
+  sl.registerLazySingleton<WalletRemoteDataSource>(
+    () => WalletRemoteDataSource(
+      baseUrl: '${_baseUrl()}/api/wallets/',
+      token: token,
+      dio: sl<DioClient>().dio,
+    ),
+  );
 
-sl.registerLazySingletonAsync<WalletRemoteDataSource>(
-  () async => WalletRemoteDataSource(
-    token: await sl<AuthLocalDataSource>().getToken() ?? "", // await async token retrieval
-    dio: sl<DioClient>().dio,
-  ),
-);
-  
+  sl.registerLazySingleton<WalletRepository>(
+    () => WalletRepositoryImpl(remoteDataSource: sl()),
+  );
+
   // Register use case
   sl.registerLazySingleton(() => GetWalletsUseCase(sl()));
-  
+
   // Register WalletViewModel as a factory so you get a new instance when needed.
   sl.registerFactory(() => WalletViewModel(getWalletsUseCase: sl()));
 }


### PR DESCRIPTION
## Summary
- add wallet remote data source and repository registrations in GetIt
- expose wallet use case and view model through service locator

## Testing
- `dart format lib/dependency_injection/di.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68930fd8fb20832e97ca76adce217698