### PR TITLE
Add wallet connect dialog and fetch logic

### DIFF
--- a/lib/dependency_injection/di.dart
+++ b/lib/dependency_injection/di.dart
@@ -77,10 +77,10 @@ Future<void> init() async {
   sl.registerLazySingleton(() => ConnectWalletUseCase(sl()));  // <-- add this
 
   // Wallet ViewModel now takes two use-cases
-  sl.registerFactory(
+  sl.registerLazySingleton(
     () => WalletViewModel(
       getWalletsUseCase: sl(),
-      connectWalletUseCase: sl(),   // <-- updated
+      connectWalletUseCase: sl(), // <-- updated
     ),
   );
 }

--- a/lib/features/data/data_sources/walletRemoteDataSource.dart
+++ b/lib/features/data/data_sources/walletRemoteDataSource.dart
@@ -3,7 +3,7 @@ import '../../domain/entities/wallet.dart';
 
 class WalletRemoteDataSource {
   final String baseUrl;
-  final String token;
+  String token;
   final Dio dio;
 
   WalletRemoteDataSource({

--- a/lib/features/presentation/pages/Authentication/LogIn/Views/login_views.dart
+++ b/lib/features/presentation/pages/Authentication/LogIn/Views/login_views.dart
@@ -1,6 +1,8 @@
 import 'package:cryphoria_mobile/dependency_injection/di.dart';
+import 'package:cryphoria_mobile/features/data/data_sources/walletRemoteDataSource.dart';
 import 'package:cryphoria_mobile/features/presentation/pages/Authentication/LogIn/ViewModel/login_ViewModel.dart';
 import 'package:cryphoria_mobile/features/presentation/pages/Authentication/Register/Views/register_view.dart';
+import 'package:cryphoria_mobile/features/presentation/pages/Home/home_ViewModel/home_Viewmodel.dart';
 import 'package:cryphoria_mobile/features/presentation/widgets/widget_tree.dart';
 import 'package:flutter/material.dart';
 
@@ -22,12 +24,15 @@ class _LogInState extends State<LogIn> {
     _viewModel.addListener(_onViewModelChanged);
   }
 
-  void _onViewModelChanged() {
+  void _onViewModelChanged() async {
     if (_viewModel.authUser != null) {
+      // Update wallet token and fetch wallets for authenticated user
+      sl<WalletRemoteDataSource>().token = _viewModel.authUser!.token;
+      await sl<WalletViewModel>().fetchWallets();
       Navigator.pushReplacement(
-      context,
-      MaterialPageRoute(builder: (_) => const WidgetTree()),
-    );
+        context,
+        MaterialPageRoute(builder: (_) => const WidgetTree()),
+      );
     } else if (_viewModel.error != null) {
       ScaffoldMessenger.of(
         context,

--- a/lib/features/presentation/pages/Home/home_views/homeView.dart
+++ b/lib/features/presentation/pages/Home/home_views/homeView.dart
@@ -47,20 +47,12 @@ class _HomeScreenState extends State<HomeScreen> {
         });
       });
 
-    if (!sl.isRegistered<WalletViewModel>()) {
-      sl.registerLazySingleton<WalletViewModel>(
-            () => WalletViewModel(getWalletsUseCase: sl(), connectWalletUseCase: sl()),
-      );
-    } else {
-      sl<WalletViewModel>().fetchWallets();
-    }
-    _walletViewModel = sl<WalletViewModel>()..fetchWallets();
+    _walletViewModel = sl<WalletViewModel>();
   }
 
   @override
   void dispose() {
     _scrollController.dispose();
-    _walletViewModel.dispose();
     super.dispose();
   }
 
@@ -174,9 +166,14 @@ class _HomeScreenState extends State<HomeScreen> {
                     );
                   }
                   if (_walletViewModel.wallets.isEmpty) {
-                    return const SizedBox(
+                    return SizedBox(
                       height: 180,
-                      child: Center(child: Text('No wallet')),
+                      child: Center(
+                        child: ElevatedButton(
+                          onPressed: _showConnectWalletDialog,
+                          child: const Text('Connect Wallet'),
+                        ),
+                      ),
                     );
                   }
                   final wallet = _walletViewModel.wallets.first;
@@ -829,5 +826,35 @@ class _HomeScreenState extends State<HomeScreen> {
 
         ],
     );
+  }
+
+  Future<void> _showConnectWalletDialog() async {
+    final walletType = await showDialog<String>(
+      context: context,
+      builder: (context) {
+        return SimpleDialog(
+          title: const Text('Connect Wallet'),
+          children: [
+            SimpleDialogOption(
+              onPressed: () => Navigator.pop(context, 'metamask'),
+              child: const Text('MetaMask'),
+            ),
+            SimpleDialogOption(
+              onPressed: () => Navigator.pop(context, 'coinbase'),
+              child: const Text('Coinbase'),
+            ),
+            SimpleDialogOption(
+              onPressed: () => Navigator.pop(context, 'trust_wallet'),
+              child: const Text('Trust Wallet'),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (walletType != null) {
+      await _walletViewModel.fetchWallets();
+      setState(() {});
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Add Connect Wallet button and selection dialog
- Load user wallets using authentication token after login
- Register WalletViewModel as singleton and allow token updates

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893659d66fc832ebf385d5a77e1268e