### PR TITLE
feat: add wallet connector service

### DIFF
--- a/lib/dependency_injection/di.dart
+++ b/lib/dependency_injection/di.dart
@@ -5,6 +5,7 @@ import 'package:cryphoria_mobile/features/data/data_sources/AuthRemoteDataSource
 import 'package:cryphoria_mobile/features/data/data_sources/walletRemoteDataSource.dart';
 import 'package:cryphoria_mobile/features/data/repositories_impl/AuthRepositoryImpl.dart';
 import 'package:cryphoria_mobile/features/data/repositories_impl/walletRepositoryimpl.dart';
+import 'package:cryphoria_mobile/features/data/services/wallet_connector_service.dart';
 import 'package:cryphoria_mobile/features/domain/repositories/auth_repository.dart';
 import 'package:cryphoria_mobile/features/domain/repositories/wallet_repository.dart';
 import 'package:cryphoria_mobile/features/domain/usecases/Login/login_usecase.dart';
@@ -28,6 +29,11 @@ Future<void> init() async {
   // Core
   sl.registerLazySingleton<AuthLocalDataSource>(() => AuthLocalDataSourceImpl(sharedPreferences: sl()));
   sl.registerLazySingleton(() => DioClient(localDataSource: sl(), dio: Dio()));
+
+  // Wallet connector service
+  sl.registerLazySingleton(
+    () => WalletConnectorService(projectId: 'YOUR_PROJECT_ID'),
+  );
 
   String _baseUrl() {
     if (Platform.isAndroid) {

--- a/lib/features/data/services/wallet_connector_service.dart
+++ b/lib/features/data/services/wallet_connector_service.dart
@@ -1,0 +1,76 @@
+import 'package:url_launcher/url_launcher.dart';
+import 'package:walletconnect_flutter_v2/walletconnect_flutter_v2.dart';
+
+/// Service responsible for connecting to wallets via WalletConnect and
+/// returning the connected address and a signed message.
+class WalletConnectorService {
+  late final Web3App _web3App;
+
+  WalletConnectorService({
+    required String projectId,
+    String relayUrl = 'wss://relay.walletconnect.com',
+  }) {
+    _web3App = Web3App(
+      projectId: projectId,
+      relayUrl: relayUrl,
+      metadata: const PairingMetadata(
+        name: 'Cryphoria',
+        description: 'Cryphoria Wallet Connector',
+        url: 'https://cryphoria.app',
+        icons: [],
+      ),
+    );
+  }
+
+  /// Connects to the specified [wallet] and requests a signature for [message].
+  ///
+  /// Returns a tuple containing the connected address and the resulting
+  /// signature.
+  Future<(String, String)> connectAndSign({
+    required String wallet,
+    required String message,
+  }) async {
+    final session = await _web3App.connect(
+      requiredNamespaces: const {
+        'eip155': RequiredNamespace(
+          chains: ['eip155:1'],
+          methods: ['personal_sign'],
+          events: [],
+        ),
+      },
+      onDisplayUri: (uri) async {
+        final link = _buildDeepLink(wallet, uri);
+        await launchUrl(Uri.parse(link),
+            mode: LaunchMode.externalApplication);
+      },
+    );
+
+    final account =
+        session.namespaces['eip155']!.accounts.first.split(':').last;
+
+    final signature = await _web3App.request(
+      topic: session.topic,
+      chainId: 'eip155:1',
+      request: SessionRequestParams(
+        method: 'personal_sign',
+        params: [message, account],
+      ),
+    );
+
+    return (account, signature as String);
+  }
+
+  String _buildDeepLink(String wallet, String uri) {
+    switch (wallet.toLowerCase()) {
+      case 'metamask':
+        return 'metamask://wc?uri=$uri';
+      case 'coinbase':
+        return 'coinbase://wc?uri=$uri';
+      case 'trust':
+      case 'trustwallet':
+        return 'trust://wc?uri=$uri';
+      default:
+        return uri;
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,8 @@ dependencies:
   dio: ^5.8.0+1
   get_it: ^7.6.0
   shared_preferences: ^2.2.2
+  walletconnect_flutter_v2: ^2.0.8
+  url_launcher: ^6.2.5
 
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- add wallet connect and url launcher dependencies
- create WalletConnectorService to manage wallet connections and signing
- register wallet connector service in dependency injection

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart format lib/dependency_injection/di.dart lib/features/data/services/wallet_connector_service.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689369c6fd7c832e9e8b95490bd66d48