### PR TITLE
Refactor wallet connection to use address and signature

### DIFF
--- a/lib/features/data/data_sources/walletRemoteDataSource.dart
+++ b/lib/features/data/data_sources/walletRemoteDataSource.dart
@@ -54,14 +54,19 @@ class WalletRemoteDataSource {
 
   Future<Wallet> connectWallet({
     required String walletType, // e.g. 'metamask', 'coinbase', 'trust_wallet'
-    required String privateKey,
+    required String address,
+    required String signature,
     String walletName = '',
   }) async {
     final type = walletType.toLowerCase();
     final url = '$baseUrl/connect_$type/';
     final response = await dio.post(
       url,
-      data: {'private_key': privateKey, 'wallet_name': walletName},
+      data: {
+        'address': address,
+        'signature': signature,
+        'wallet_name': walletName,
+      },
     );
     return Wallet.fromJson(response.data['data']);
   }

--- a/lib/features/data/repositories_impl/walletRepositoryimpl.dart
+++ b/lib/features/data/repositories_impl/walletRepositoryimpl.dart
@@ -20,12 +20,14 @@ class WalletRepositoryImpl implements WalletRepository {
  @override
   Future<Wallet> connectWallet({
     required String walletType,
-    required String privateKey,
+    required String address,
+    required String signature,
     String walletName = '',
   }) {
     return remoteDataSource.connectWallet(
       walletType: walletType,
-      privateKey: privateKey,
+      address: address,
+      signature: signature,
       walletName: walletName,
     );
   }

--- a/lib/features/domain/repositories/wallet_repository.dart
+++ b/lib/features/domain/repositories/wallet_repository.dart
@@ -6,7 +6,8 @@ abstract class WalletRepository {
   Future<Wallet> addWallet(Wallet wallet);
   Future<Wallet> connectWallet({
     required String walletType,
-    required String privateKey,
+    required String address,
+    required String signature,
     String walletName = '',
   });
 }

--- a/lib/features/domain/usecases/wallet/wallet_usecase.dart
+++ b/lib/features/domain/usecases/wallet/wallet_usecase.dart
@@ -17,12 +17,14 @@ class ConnectWalletUseCase {
 
   Future<Wallet> execute({
     required String walletType,
-    required String privateKey,
+    required String address,
+    required String signature,
     String walletName = '',
   }) {
     return repository.connectWallet(
       walletType: walletType,
-      privateKey: privateKey,
+      address: address,
+      signature: signature,
       walletName: walletName,
     );
   }

--- a/lib/features/presentation/pages/Home/home_ViewModel/home_Viewmodel.dart
+++ b/lib/features/presentation/pages/Home/home_ViewModel/home_Viewmodel.dart
@@ -34,7 +34,8 @@ class WalletViewModel extends ChangeNotifier {
   }
   Future<void> connectWallet({
     required String walletType,
-    required String privateKey,
+    required String address,
+    required String signature,
     String walletName = '',
   }) async {
     _isLoading = true;
@@ -42,7 +43,8 @@ class WalletViewModel extends ChangeNotifier {
     try {
       final newWallet = await connectWalletUseCase.execute(
         walletType: walletType,
-        privateKey: privateKey,
+        address: address,
+        signature: signature,
         walletName: walletName,
       );
       _wallets.insert(0, newWallet);


### PR DESCRIPTION
## Summary
- Refactor wallet connection flow to send address and signed message instead of private key
- Update wallet repository, use case, and view model to match new parameters

## Testing
- `dart analyze` *(fails: Target of URI doesn't exist: 'package:flutter/material.dart')*
- `dart test` *(fails: Because cryphoria_mobile depends on flutter_test from sdk which doesn't exist (the Flutter SDK is not available))*

------
https://chatgpt.com/codex/tasks/task_e_689369c8bef8832e9f8c0fd605fb85f3