### PR TITLE
refactor: async wallet connector registration

### DIFF
--- a/lib/dependency_injection/di.dart
+++ b/lib/dependency_injection/di.dart
@@ -31,8 +31,10 @@ Future<void> init() async {
   sl.registerLazySingleton(() => DioClient(localDataSource: sl(), dio: Dio()));
 
   // Wallet connector service
-  sl.registerLazySingleton(
-    () => WalletConnectorService.create(projectId: 'YOUR_PROJECT_ID'),
+  sl.registerSingletonAsync<WalletConnectorService>(
+    () async => WalletConnectorService.create(
+      projectId: 'a6ae708b14c911a7920025033c8a5a99',
+    ),
   );
 
   String _baseUrl() {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,10 +1,12 @@
 import 'package:cryphoria_mobile/dependency_injection/di.dart' as di;
 import 'package:flutter/material.dart';
+import 'package:cryphoria_mobile/features/data/services/wallet_connector_service.dart';
 import 'package:cryphoria_mobile/features/presentation/pages/Authentication/LogIn/Views/login_views.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await di.init();
+  await di.sl.isReady<WalletConnectorService>();
   runApp(const MyApp());
 }
 


### PR DESCRIPTION
## Summary
- register WalletConnectorService asynchronously with project id
- ensure startup awaits WalletConnectorService before running app

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package)*


------
https://chatgpt.com/codex/tasks/task_e_68937eb45358832eaed6a0b681e2c737