### PR TITLE
Require explicit wallet endpoint for MetaMask support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,17 @@
 
 The app connects to a user wallet using a simple private–key dialog. On a
 successful connection the key is stored locally in encrypted storage and the
-wallet balance is fetched from the backend.
+wallet balance is fetched from the backend. Callers must now specify which
+wallet to connect by providing both the API endpoint and wallet name. Use the
+`connect_trust_wallet/` endpoint with the name `Mobile Wallet` for Trust Wallet
+or `connect_metamask/` with the name `MetaMask` for MetaMask.
 
 ### Endpoints
 
 | Action | Endpoint |
 |--------|----------|
-| Connect | `POST /api/wallets/connect_trust_wallet/` |
+| Connect (Trust Wallet) | `POST /api/wallets/connect_trust_wallet/` |
+| Connect (MetaMask) | `POST /api/wallets/connect_metamask/` |
 | Get Balance | `POST /api/wallets/get_specific_wallet_balance/` |
 | Reconnect | `POST /api/wallets/reconnect_wallet_with_private_key/` |
 

--- a/lib/features/data/services/wallet_service.dart
+++ b/lib/features/data/services/wallet_service.dart
@@ -8,11 +8,16 @@ class WalletService {
 
   WalletService({required this.remoteDataSource, required this.storage});
 
-  Future<Wallet> connectWithPrivateKey(String privateKey,
-      {String endpoint = 'connect_trust_wallet/',
-      String walletName = 'Mobile Wallet'}) async {
+  Future<Wallet> connectWithPrivateKey(
+    String privateKey, {
+    required String endpoint,
+    required String walletName,
+  }) async {
     final address = await remoteDataSource.connectWithPrivateKey(
-        endpoint: endpoint, privateKey: privateKey, walletName: walletName);
+      endpoint: endpoint,
+      privateKey: privateKey,
+      walletName: walletName,
+    );
     await storage.saveKey(privateKey);
     final balance = await remoteDataSource.getBalance(address);
     return Wallet(id: '', name: walletName, address: address, balance: balance);

--- a/lib/features/presentation/pages/Home/home_ViewModel/home_Viewmodel.dart
+++ b/lib/features/presentation/pages/Home/home_ViewModel/home_Viewmodel.dart
@@ -13,11 +13,19 @@ class WalletViewModel extends ChangeNotifier {
   Wallet? get wallet => _wallet;
   bool get isLoading => _isLoading;
 
-  Future<void> connect(String privateKey) async {
+  Future<void> connect(
+    String privateKey, {
+    required String endpoint,
+    required String walletName,
+  }) async {
     _isLoading = true;
     notifyListeners();
     try {
-      _wallet = await walletService.connectWithPrivateKey(privateKey);
+      _wallet = await walletService.connectWithPrivateKey(
+        privateKey,
+        endpoint: endpoint,
+        walletName: walletName,
+      );
     } finally {
       _isLoading = false;
       notifyListeners();

--- a/lib/features/presentation/pages/Home/home_views/homeView.dart
+++ b/lib/features/presentation/pages/Home/home_views/homeView.dart
@@ -830,26 +830,56 @@ class _HomeScreenState extends State<HomeScreen> {
 
   Future<void> _showConnectWalletDialog() async {
     final controller = TextEditingController();
+    String selectedWallet = 'Trust Wallet';
+
     final shouldConnect = await showDialog<bool>(
       context: context,
       builder: (context) {
-        return AlertDialog(
-          title: const Text('Enter private key'),
-          content: TextField(
-            controller: controller,
-            obscureText: true,
-            decoration: const InputDecoration(labelText: 'Private key'),
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context, false),
-              child: const Text('Cancel'),
-            ),
-            TextButton(
-              onPressed: () => Navigator.pop(context, true),
-              child: const Text('Connect'),
-            ),
-          ],
+        return StatefulBuilder(
+          builder: (context, setState) {
+            return AlertDialog(
+              title: const Text('Enter private key'),
+              content: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  TextField(
+                    controller: controller,
+                    obscureText: true,
+                    decoration: const InputDecoration(labelText: 'Private key'),
+                  ),
+                  const SizedBox(height: 12),
+                  DropdownButton<String>(
+                    value: selectedWallet,
+                    items: const [
+                      DropdownMenuItem(
+                        value: 'Trust Wallet',
+                        child: Text('Trust Wallet'),
+                      ),
+                      DropdownMenuItem(
+                        value: 'MetaMask',
+                        child: Text('MetaMask'),
+                      ),
+                    ],
+                    onChanged: (value) {
+                      if (value != null) {
+                        setState(() => selectedWallet = value);
+                      }
+                    },
+                  ),
+                ],
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.pop(context, false),
+                  child: const Text('Cancel'),
+                ),
+                TextButton(
+                  onPressed: () => Navigator.pop(context, true),
+                  child: const Text('Connect'),
+                ),
+              ],
+            );
+          },
         );
       },
     );
@@ -861,7 +891,16 @@ class _HomeScreenState extends State<HomeScreen> {
         builder: (_) => const Center(child: CircularProgressIndicator()),
       );
       try {
-        await _walletViewModel.connect(controller.text);
+        final endpoint = selectedWallet == 'MetaMask'
+            ? 'connect_metamask/'
+            : 'connect_trust_wallet/';
+        final walletName =
+            selectedWallet == 'MetaMask' ? 'MetaMask' : 'Mobile Wallet';
+        await _walletViewModel.connect(
+          controller.text,
+          endpoint: endpoint,
+          walletName: walletName,
+        );
         setState(() {});
       } catch (e) {
         ScaffoldMessenger.of(context).showSnackBar(

--- a/test/wallet_service_test.dart
+++ b/test/wallet_service_test.dart
@@ -27,7 +27,11 @@ void main() {
       remoteDataSource: FakeRemote(),
       storage: MemoryStorage(),
     );
-    final wallet = await service.connectWithPrivateKey('k');
+    final wallet = await service.connectWithPrivateKey(
+      'k',
+      endpoint: 'connect_trust_wallet/',
+      walletName: 'Mobile Wallet',
+    );
     expect(wallet.address, 'addr');
     expect(wallet.balance, 5.0);
   });


### PR DESCRIPTION
## Summary
- remove default Trust Wallet endpoint so callers must specify the target wallet
- allow picking Trust Wallet or MetaMask in UI and forward endpoint/name
- document wallet selection flow and update tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894ccbdad74832e8cfb09dae019bda2