### PR TITLE
Secure wallet key storage and public address transmission

### DIFF
--- a/lib/features/data/data_sources/walletRemoteDataSource.dart
+++ b/lib/features/data/data_sources/walletRemoteDataSource.dart
@@ -52,6 +52,7 @@ class WalletRemoteDataSource {
     required String endpoint,
     required String walletAddress,
     required String walletName,
+    required String walletType,
   }) async {
     final url = '$baseUrl$endpoint';
     try {
@@ -63,8 +64,9 @@ class WalletRemoteDataSource {
           },
         ),
         data: {
-          'wallet_address': walletAddress,
+          'address': walletAddress,
           'wallet_name': walletName,
+          'wallet_type': walletType,
         },
       );
     } on DioError catch (e) {

--- a/lib/features/data/services/wallet_service.dart
+++ b/lib/features/data/services/wallet_service.dart
@@ -13,14 +13,16 @@ class WalletService {
     String privateKey, {
     required String endpoint,
     required String walletName,
+    required String walletType,
   }) async {
+    await storage.saveKey(privateKey);
     final creds = EthPrivateKey.fromHex(privateKey);
     final address = creds.address.hexEip55;
-    await storage.saveKey(privateKey);
     await remoteDataSource.registerWallet(
       endpoint: endpoint,
       walletAddress: address,
       walletName: walletName,
+      walletType: walletType,
     );
     final balance = await remoteDataSource.getBalance(address);
     return Wallet(id: '', name: walletName, address: address, balance: balance);

--- a/lib/features/presentation/pages/Authentication/LogIn/Views/login_views.dart
+++ b/lib/features/presentation/pages/Authentication/LogIn/Views/login_views.dart
@@ -26,8 +26,7 @@ class _LogInState extends State<LogIn> {
 
   void _onViewModelChanged() async {
     if (_viewModel.authUser != null) {
-      // Update wallet token and reconnect stored wallet if any
-      sl<WalletRemoteDataSource>().token = _viewModel.authUser!.token;
+      // Reconnect stored wallet if any
       await sl<WalletViewModel>().reconnect();
       Navigator.pushReplacement(
         context,

--- a/lib/features/presentation/pages/Home/home_ViewModel/home_Viewmodel.dart
+++ b/lib/features/presentation/pages/Home/home_ViewModel/home_Viewmodel.dart
@@ -18,6 +18,7 @@ class WalletViewModel extends ChangeNotifier {
     String privateKey, {
     required String endpoint,
     required String walletName,
+    required String walletType,
   }) async {
     _isLoading = true;
     notifyListeners();
@@ -26,6 +27,7 @@ class WalletViewModel extends ChangeNotifier {
         privateKey,
         endpoint: endpoint,
         walletName: walletName,
+        walletType: walletType,
       );
     } finally {
       _isLoading = false;

--- a/lib/features/presentation/pages/Home/home_views/homeView.dart
+++ b/lib/features/presentation/pages/Home/home_views/homeView.dart
@@ -900,6 +900,7 @@ class _HomeScreenState extends State<HomeScreen> {
           controller.text,
           endpoint: endpoint,
           walletName: walletName,
+          walletType: selectedWallet,
         );
         setState(() {});
       } catch (e) {

--- a/test/wallet_service_test.dart
+++ b/test/wallet_service_test.dart
@@ -12,6 +12,7 @@ class FakeRemote extends WalletRemoteDataSource {
     required String endpoint,
     required String walletAddress,
     required String walletName,
+    required String walletType,
   }) async {}
 
   @override
@@ -32,6 +33,7 @@ void main() {
       key,
       endpoint: 'connect_trust_wallet/',
       walletName: 'Mobile Wallet',
+      walletType: 'Trust Wallet',
     );
     final expected = EthPrivateKey.fromHex(key).address.hexEip55;
     expect(wallet.address, expected);


### PR DESCRIPTION
## Summary
- Store private keys in secure storage before deriving the wallet's EIP-55 address
- Register wallets by sending only the public address along with name and type
- Rely on stored auth token for authorized requests without manual propagation

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894da2426b8832eab4c84a7862d9890