### PR TITLE
Check stored wallet before reconnecting on login

### DIFF
--- a/lib/features/data/services/wallet_service.dart
+++ b/lib/features/data/services/wallet_service.dart
@@ -28,6 +28,11 @@ class WalletService {
     return Wallet(id: '', name: walletName, address: address, balance: balance);
   }
 
+  Future<bool> hasStoredWallet() async {
+    final key = await storage.readKey();
+    return key != null && key.isNotEmpty;
+  }
+
   Future<Wallet?> reconnect() async {
     final key = await storage.readKey();
     if (key == null || key.isEmpty) return null;

--- a/lib/features/presentation/pages/Authentication/LogIn/Views/login_views.dart
+++ b/lib/features/presentation/pages/Authentication/LogIn/Views/login_views.dart
@@ -1,5 +1,5 @@
 import 'package:cryphoria_mobile/dependency_injection/di.dart';
-import 'package:cryphoria_mobile/features/data/data_sources/walletRemoteDataSource.dart';
+import 'package:cryphoria_mobile/features/data/services/wallet_service.dart';
 import 'package:cryphoria_mobile/features/presentation/pages/Authentication/LogIn/ViewModel/login_ViewModel.dart';
 import 'package:cryphoria_mobile/features/presentation/pages/Authentication/Register/Views/register_view.dart';
 import 'package:cryphoria_mobile/features/presentation/pages/Home/home_ViewModel/home_Viewmodel.dart';
@@ -26,8 +26,9 @@ class _LogInState extends State<LogIn> {
 
   void _onViewModelChanged() async {
     if (_viewModel.authUser != null) {
-      // Reconnect stored wallet if any
-      await sl<WalletViewModel>().reconnect();
+      if (await sl<WalletService>().hasStoredWallet()) {
+        await sl<WalletViewModel>().reconnect();
+      }
       Navigator.pushReplacement(
         context,
         MaterialPageRoute(builder: (_) => const WidgetTree()),


### PR DESCRIPTION
## Summary
- add `hasStoredWallet` helper to `WalletService`
- only reconnect wallet after login when a stored key exists

## Testing
- `dart analyze` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `snap install flutter --classic` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894e3748b90832ebc7111453c325740