### PR TITLE
Use GET for wallet balance retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ or `connect_metamask/` with the name `MetaMask` for MetaMask.
 |--------|----------|
 | Connect (Trust Wallet) | `POST /api/wallets/connect_trust_wallet/` |
 | Connect (MetaMask) | `POST /api/wallets/connect_metamask/` |
-| Get Balance | `POST /api/wallets/get_specific_wallet_balance/` |
+| Get Balance | `GET /api/wallets/get_wallet_balance/` |
 | Reconnect | `POST /api/wallets/reconnect_wallet_with_private_key/` |
 
 ### Running Tests

--- a/lib/features/data/data_sources/walletRemoteDataSource.dart
+++ b/lib/features/data/data_sources/walletRemoteDataSource.dart
@@ -77,14 +77,14 @@ class WalletRemoteDataSource {
   Future<double> getBalance(String walletAddress) async {
     final url = '${baseUrl}get_wallet_balance/';
     try {
-      final response = await dio.post(
+      final response = await dio.get(
         url,
         options: Options(
           headers: {
             "Content-Type": "application/json",
           },
         ),
-        data: {
+        queryParameters: {
           'wallet_address': walletAddress,
         },
       );


### PR DESCRIPTION
## Summary
- switch wallet balance request to `GET /api/wallets/get_wallet_balance/`
- document updated balance endpoint

## Testing
- `flutter pub get`
- `flutter test` (fails: RegisterViewModel not registered)


------
https://chatgpt.com/codex/tasks/task_e_6894e575c124832ebea1694ead4b8778