### PR TITLE
Fetch wallet after login

### DIFF
--- a/lib/features/presentation/pages/Authentication/LogIn/Views/login_views.dart
+++ b/lib/features/presentation/pages/Authentication/LogIn/Views/login_views.dart
@@ -1,8 +1,6 @@
 import 'package:cryphoria_mobile/dependency_injection/di.dart';
-import 'package:cryphoria_mobile/features/data/services/wallet_service.dart';
 import 'package:cryphoria_mobile/features/presentation/pages/Authentication/LogIn/ViewModel/login_ViewModel.dart';
 import 'package:cryphoria_mobile/features/presentation/pages/Authentication/Register/Views/register_view.dart';
-import 'package:cryphoria_mobile/features/presentation/pages/Home/home_ViewModel/home_Viewmodel.dart';
 import 'package:cryphoria_mobile/features/presentation/widgets/widget_tree.dart';
 import 'package:flutter/material.dart';
 
@@ -26,9 +24,6 @@ class _LogInState extends State<LogIn> {
 
   void _onViewModelChanged() async {
     if (_viewModel.authUser != null) {
-      if (await sl<WalletService>().hasStoredWallet()) {
-        await sl<WalletViewModel>().reconnect();
-      }
       Navigator.pushReplacement(
         context,
         MaterialPageRoute(builder: (_) => const WidgetTree()),

--- a/lib/features/presentation/pages/Home/home_views/homeView.dart
+++ b/lib/features/presentation/pages/Home/home_views/homeView.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:cryphoria_mobile/features/domain/entities/payroll_history.dart';
 import 'package:cryphoria_mobile/features/data/data_sources/fake_payroll_data.dart';
 import 'package:cryphoria_mobile/dependency_injection/di.dart';
+import 'package:cryphoria_mobile/features/data/services/wallet_service.dart';
 import 'package:cryphoria_mobile/features/presentation/pages/Home/home_ViewModel/home_Viewmodel.dart';
 import '../../../widgets/invoice_detail_card.dart';
 import '../../../widgets/glass_payroll_history_item.dart';
@@ -48,6 +49,12 @@ class _HomeScreenState extends State<HomeScreen> {
       });
 
     _walletViewModel = sl<WalletViewModel>();
+
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      if (await sl<WalletService>().hasStoredWallet()) {
+        await _walletViewModel.reconnect();
+      }
+    });
   }
 
   @override


### PR DESCRIPTION
## Summary
- stop wallet reconnect during login and navigate directly after authentication
- lazily reconnect stored wallet on the home screen after login

## Testing
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894e9daf188832ea9a66e59ff588fe8