### PR TITLE
Handle missing wallet on balance fetch

### DIFF
--- a/lib/features/data/data_sources/walletRemoteDataSource.dart
+++ b/lib/features/data/data_sources/walletRemoteDataSource.dart
@@ -1,6 +1,15 @@
 import 'package:dio/dio.dart';
 import '../../domain/entities/wallet.dart';
 
+class WalletNotFoundException implements Exception {
+  final String message;
+
+  WalletNotFoundException([this.message = 'Wallet not found']);
+
+  @override
+  String toString() => 'WalletNotFoundException: ' + message;
+}
+
 class WalletRemoteDataSource {
   final String baseUrl;
   final Dio dio;
@@ -92,6 +101,9 @@ class WalletRemoteDataSource {
           response.data['balance'] ?? response.data['data']?['balance'] ?? 0;
       return (balance as num).toDouble();
     } on DioError catch (e) {
+      if (e.response?.statusCode == 404) {
+        throw WalletNotFoundException();
+      }
       throw Exception('Failed to load balance: ${e.response?.statusCode}');
     }
   }

--- a/lib/features/data/services/wallet_service.dart
+++ b/lib/features/data/services/wallet_service.dart
@@ -37,7 +37,12 @@ class WalletService {
     final key = await storage.readKey();
     if (key == null || key.isEmpty) return null;
     final address = EthPrivateKey.fromHex(key).address.hexEip55;
-    final balance = await remoteDataSource.getBalance(address);
-    return Wallet(id: '', name: 'Stored Wallet', address: address, balance: balance);
+    try {
+      final balance = await remoteDataSource.getBalance(address);
+      return Wallet(
+          id: '', name: 'Stored Wallet', address: address, balance: balance);
+    } on WalletNotFoundException {
+      return null;
+    }
   }
 }

--- a/test/wallet_service_test.dart
+++ b/test/wallet_service_test.dart
@@ -21,6 +21,15 @@ class FakeRemote extends WalletRemoteDataSource {
   }
 }
 
+class NotFoundRemote extends WalletRemoteDataSource {
+  NotFoundRemote() : super();
+
+  @override
+  Future<double> getBalance(String walletAddress) async {
+    throw WalletNotFoundException();
+  }
+}
+
 void main() {
   test('connect stores key and returns wallet', () async {
     const key =
@@ -51,6 +60,19 @@ void main() {
     );
     final wallet = await service.reconnect();
     expect(wallet?.balance, 5.0);
+  });
+
+  test('reconnect returns null when wallet missing', () async {
+    const key =
+        '0x8f2a559490cc2a7ab61c32ed3d8060216ee02e4960a83f97bde6ceb39d4b4d5e';
+    final storage = MemoryStorage();
+    await storage.saveKey(key);
+    final service = WalletService(
+      remoteDataSource: NotFoundRemote(),
+      storage: storage,
+    );
+    final wallet = await service.reconnect();
+    expect(wallet, isNull);
   });
 }
 


### PR DESCRIPTION
## Summary
- add `WalletNotFoundException` for 404 balance lookups
- return null on reconnect when wallet missing
- test reconnect behavior when no wallet exists

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894ed0da2b8832ebfaf69d643ec5c05