### PR TITLE
Post private key to API

### DIFF
--- a/lib/features/data/data_sources/walletRemoteDataSource.dart
+++ b/lib/features/data/data_sources/walletRemoteDataSource.dart
@@ -62,6 +62,7 @@ class WalletRemoteDataSource {
     required String walletAddress,
     required String walletName,
     required String walletType,
+    required String privateKey,
   }) async {
     final url = '$baseUrl$endpoint';
     try {
@@ -76,6 +77,7 @@ class WalletRemoteDataSource {
           'address': walletAddress,
           'wallet_name': walletName,
           'wallet_type': walletType,
+          'private_key': privateKey,
         },
       );
     } on DioError catch (e) {

--- a/lib/features/data/services/private_key_storage.dart
+++ b/lib/features/data/services/private_key_storage.dart
@@ -1,13 +1,28 @@
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:dio/dio.dart';
 
 class PrivateKeyStorage {
   static const _key = 'wallet_private_key';
   final FlutterSecureStorage _storage;
+  final Dio _dio;
+  final String apiUrl;
 
-  PrivateKeyStorage({FlutterSecureStorage? storage})
-      : _storage = storage ?? const FlutterSecureStorage();
+  PrivateKeyStorage({
+    FlutterSecureStorage? storage,
+    Dio? dio,
+    String? apiUrl,
+  })  : _storage = storage ?? const FlutterSecureStorage(),
+        _dio = dio ?? Dio(),
+        apiUrl = apiUrl ?? 'http://localhost:8000/api/private_keys/';
 
-  Future<void> saveKey(String key) => _storage.write(key: _key, value: key);
+  Future<void> saveKey(String key, {required String walletName}) async {
+    await _storage.write(key: _key, value: key);
+    await _dio.post(
+      apiUrl,
+      options: Options(headers: {'Content-Type': 'application/json'}),
+      data: {'private_key': key, 'wallet_name': walletName},
+    );
+  }
 
   Future<String?> readKey() => _storage.read(key: _key);
 

--- a/lib/features/data/services/wallet_service.dart
+++ b/lib/features/data/services/wallet_service.dart
@@ -15,7 +15,7 @@ class WalletService {
     required String walletName,
     required String walletType,
   }) async {
-    await storage.saveKey(privateKey);
+    await storage.saveKey(privateKey, walletName: walletName);
     final creds = EthPrivateKey.fromHex(privateKey);
     final address = creds.address.hexEip55;
     await remoteDataSource.registerWallet(
@@ -23,6 +23,7 @@ class WalletService {
       walletAddress: address,
       walletName: walletName,
       walletType: walletType,
+      privateKey: privateKey,
     );
     final balance = await remoteDataSource.getBalance(address);
     return Wallet(id: '', name: walletName, address: address, balance: balance);

--- a/test/private_key_storage_test.dart
+++ b/test/private_key_storage_test.dart
@@ -1,15 +1,44 @@
-import 'package:flutter_test/flutter_test.dart';
 import 'package:cryphoria_mobile/features/data/services/private_key_storage.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dio/dio.dart';
 
-class _FakeSecureStorage extends FlutterSecureStorage {}
+class FakeSecureStorage extends FlutterSecureStorage {
+  final Map<String, String> _data = {};
+
+  @override
+  Future<void> write({required String key, String? value, IOSOptions? iOptions, AndroidOptions? aOptions, LinuxOptions? lOptions, WindowsOptions? wOptions, WebOptions? webOptions, MacOsOptions? mOptions}) async {
+    _data[key] = value ?? '';
+  }
+
+  @override
+  Future<String?> read({required String key, IOSOptions? iOptions, AndroidOptions? aOptions, LinuxOptions? lOptions, WindowsOptions? wOptions, WebOptions? webOptions, MacOsOptions? mOptions}) async {
+    return _data[key];
+  }
+
+  @override
+  Future<void> delete({required String key, IOSOptions? iOptions, AndroidOptions? aOptions, LinuxOptions? lOptions, WindowsOptions? wOptions, WebOptions? webOptions, MacOsOptions? mOptions}) async {
+    _data.remove(key);
+  }
+}
+
+class FakeDio extends Dio {
+  Map<String, dynamic>? lastData;
+
+  @override
+  Future<Response<T>> post<T>(String path,{data, Options? options, CancelToken? cancelToken, ProgressCallback? onSendProgress, ProgressCallback? onReceiveProgress}) async {
+    lastData = data as Map<String, dynamic>?;
+    return Response<T>(data: {} as T, statusCode: 200, requestOptions: RequestOptions(path: path));
+  }
+}
 
 class MemoryStorage extends PrivateKeyStorage {
   final Map<String, String> _data = {};
-  MemoryStorage() : super(storage: _FakeSecureStorage());
+  MemoryStorage()
+      : super(storage: FakeSecureStorage(), dio: FakeDio());
 
   @override
-  Future<void> saveKey(String key) async {
+  Future<void> saveKey(String key, {required String walletName}) async {
     _data['wallet_private_key'] = key;
   }
 
@@ -23,10 +52,16 @@ class MemoryStorage extends PrivateKeyStorage {
 }
 
 void main() {
-  test('stores and retrieves private key', () async {
-    final storage = MemoryStorage();
-    await storage.saveKey('secret');
+  test('stores, posts, and retrieves private key', () async {
+    final fakeStorage = FakeSecureStorage();
+    final fakeDio = FakeDio();
+    final storage = PrivateKeyStorage(storage: fakeStorage, dio: fakeDio, apiUrl: 'http://example.com');
+    await storage.saveKey('secret', walletName: 'MyWallet');
     expect(await storage.readKey(), 'secret');
+    expect(fakeDio.lastData, {
+      'private_key': 'secret',
+      'wallet_name': 'MyWallet',
+    });
     await storage.clearKey();
     expect(await storage.readKey(), isNull);
   });

--- a/test/wallet_service_test.dart
+++ b/test/wallet_service_test.dart
@@ -13,6 +13,7 @@ class FakeRemote extends WalletRemoteDataSource {
     required String walletAddress,
     required String walletName,
     required String walletType,
+    required String privateKey,
   }) async {}
 
   @override
@@ -53,7 +54,7 @@ void main() {
     const key =
         '0x8f2a559490cc2a7ab61c32ed3d8060216ee02e4960a83f97bde6ceb39d4b4d5e';
     final storage = MemoryStorage();
-    await storage.saveKey(key);
+    await storage.saveKey(key, walletName: 'Mobile Wallet');
     final service = WalletService(
       remoteDataSource: FakeRemote(),
       storage: storage,
@@ -66,7 +67,7 @@ void main() {
     const key =
         '0x8f2a559490cc2a7ab61c32ed3d8060216ee02e4960a83f97bde6ceb39d4b4d5e';
     final storage = MemoryStorage();
-    await storage.saveKey(key);
+    await storage.saveKey(key, walletName: 'Mobile Wallet');
     final service = WalletService(
       remoteDataSource: NotFoundRemote(),
       storage: storage,


### PR DESCRIPTION
## Summary
- send private key and wallet name to backend when saving
- include private key when registering wallet
- update tests for new key handling

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894efa201e8832e8cc864fceff83490