### PR TITLE
Add Coinbase wallet option and bearer auth header

### DIFF
--- a/lib/core/network/dio_client.dart
+++ b/lib/core/network/dio_client.dart
@@ -15,7 +15,7 @@ class DioClient {
     this.dio.interceptors.add(InterceptorsWrapper(onRequest: (options, handler) async {
       final token = await localDataSource.getToken();
       if (token != null) {
-        options.headers['Authorization'] = 'Token $token';
+        options.headers['Authorization'] = 'Bearer $token';
       }
       handler.next(options);
     }));

--- a/lib/features/data/data_sources/walletRemoteDataSource.dart
+++ b/lib/features/data/data_sources/walletRemoteDataSource.dart
@@ -84,24 +84,25 @@ class WalletRemoteDataSource {
   }
 
   Future<double> getBalance(String walletAddress) async {
-    final url = '${baseUrl}get_wallet_balance/';
+    final url = '${baseUrl}get_specific_wallet_balance/';
     try {
-      final response = await dio.get(
+      final response = await dio.post(
         url,
         options: Options(
           headers: {
             "Content-Type": "application/json",
           },
         ),
-        queryParameters: {
+        data: {
           'wallet_address': walletAddress,
         },
       );
-      final balance =
-          response.data['balance'] ?? response.data['data']?['balance'] ?? 0;
-      return (balance as num).toDouble();
+      final balance = response.data['data']?['wallet']?['balances']?['ETH']?
+              ['balance'] ??
+          0;
+      return double.tryParse(balance.toString()) ?? 0;
     } on DioError catch (e) {
-      if (e.response?.statusCode == 403) {
+      if (e.response?.statusCode == 403 || e.response?.statusCode == 404) {
         throw WalletNotFoundException();
       }
       throw Exception('Failed to load balance: ${e.response?.statusCode}');

--- a/lib/features/presentation/pages/Home/home_views/homeView.dart
+++ b/lib/features/presentation/pages/Home/home_views/homeView.dart
@@ -837,7 +837,7 @@ class _HomeScreenState extends State<HomeScreen> {
 
   Future<void> _showConnectWalletDialog() async {
     final controller = TextEditingController();
-    String selectedWallet = 'Trust Wallet';
+    String selectedWallet = 'MetaMask';
 
     final shouldConnect = await showDialog<bool>(
       context: context,
@@ -859,12 +859,16 @@ class _HomeScreenState extends State<HomeScreen> {
                     value: selectedWallet,
                     items: const [
                       DropdownMenuItem(
+                        value: 'MetaMask',
+                        child: Text('MetaMask'),
+                      ),
+                      DropdownMenuItem(
                         value: 'Trust Wallet',
                         child: Text('Trust Wallet'),
                       ),
                       DropdownMenuItem(
-                        value: 'MetaMask',
-                        child: Text('MetaMask'),
+                        value: 'Coinbase',
+                        child: Text('Coinbase'),
                       ),
                     ],
                     onChanged: (value) {
@@ -898,11 +902,19 @@ class _HomeScreenState extends State<HomeScreen> {
         builder: (_) => const Center(child: CircularProgressIndicator()),
       );
       try {
-        final endpoint = selectedWallet == 'MetaMask'
-            ? 'connect_metamask/'
-            : 'connect_trust_wallet/';
-        final walletName =
-            selectedWallet == 'MetaMask' ? 'MetaMask' : 'Mobile Wallet';
+        String endpoint;
+        switch (selectedWallet) {
+          case 'MetaMask':
+            endpoint = 'connect_metamask/';
+            break;
+          case 'Coinbase':
+            endpoint = 'connect_coinbase/';
+            break;
+          case 'Trust Wallet':
+          default:
+            endpoint = 'connect_trust_wallet/';
+        }
+        final walletName = 'Main Trading $selectedWallet';
         await _walletViewModel.connect(
           controller.text,
           endpoint: endpoint,


### PR DESCRIPTION
## Summary
- support MetaMask, Trust Wallet, and Coinbase wallet selection with endpoint switch
- request wallet balances via new API endpoint
- send auth token using `Bearer` scheme

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896002105d4832eae2116235fb735dd